### PR TITLE
Install dependencies with outdated lockfile

### DIFF
--- a/netlify/functions-dev/add-map-columns.ts
+++ b/netlify/functions-dev/add-map-columns.ts
@@ -1,6 +1,6 @@
 import { Handler } from '@netlify/functions';
 import { drizzle } from 'drizzle-orm/neon-http';
-import { neon } from '@neondatabase/serverless';
+import { neon } from '@netlify/neon';
 
 export const handler: Handler = async (event, context) => {
   try {

--- a/netlify/functions-dev/assess-damage.js
+++ b/netlify/functions-dev/assess-damage.js
@@ -1,4 +1,4 @@
-import { neon } from '@neondatabase/serverless';
+import { neon } from '@netlify/neon';
 
 export const handler = async (event, context) => {
   const sql = neon(process.env.NETLIFY_DATABASE_URL || process.env.DATABASE_URL);

--- a/netlify/functions-dev/check-status.js
+++ b/netlify/functions-dev/check-status.js
@@ -1,4 +1,4 @@
-import { neon } from '@neondatabase/serverless';
+import { neon } from '@netlify/neon';
 
 export const handler = async (event, context) => {
   const sql = neon(process.env.NETLIFY_DATABASE_URL || process.env.DATABASE_URL);

--- a/netlify/functions/favorites-get.ts
+++ b/netlify/functions/favorites-get.ts
@@ -1,6 +1,6 @@
 import { Handler } from '@netlify/functions';
 import { neon } from '@netlify/neon';
-import jwt from 'jsonwebtoken';
+import * as jwt from 'jsonwebtoken';
 
 const DATABASE_URL = process.env.DATABASE_URL || process.env.NETLIFY_DATABASE_URL || "postgresql://neondb_owner:npg_RaSZ09iyfWAm@ep-winter-recipe-aejsi9db-pooler.c-2.us-east-2.aws.neon.tech/neondb?channel_binding=require&sslmode=require";
 const JWT_SECRET = process.env.JWT_SECRET || 'your-super-secret-jwt-key-change-in-production';
@@ -53,7 +53,7 @@ export const handler: Handler = async (event, context) => {
     console.log(`📋 FAVORITES: Getting saved companies for user ${decoded.userId}`);
 
     // Get saved companies using snake_case column names
-    const savedCompanies = await sql.query(`
+    const savedCompanies = await sql`
       SELECT 
         sc.id as saved_id,
         sc.saved_at,
@@ -70,11 +70,11 @@ export const handler: Handler = async (event, context) => {
         c.description
       FROM saved_companies sc
       JOIN companies c ON sc.company_id = c.id
-      WHERE sc.user_id = $1
-      ORDER BY sc.saved_at DESC;
-    `, [decoded.userId]);
+      WHERE sc.user_id = ${decoded.userId}
+      ORDER BY sc.saved_at DESC
+    `;
 
-    const savedList = savedCompanies.rows || [];
+    const savedList = savedCompanies || [];
     console.log(`✅ FAVORITES: Found ${savedList.length} saved companies`);
 
     // Format response for frontend

--- a/netlify/functions/favorites-get.ts
+++ b/netlify/functions/favorites-get.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions';
-import { neon } from '@neondatabase/serverless';
+import { neon } from '@netlify/neon';
 import jwt from 'jsonwebtoken';
 
 const DATABASE_URL = process.env.DATABASE_URL || process.env.NETLIFY_DATABASE_URL || "postgresql://neondb_owner:npg_RaSZ09iyfWAm@ep-winter-recipe-aejsi9db-pooler.c-2.us-east-2.aws.neon.tech/neondb?channel_binding=require&sslmode=require";

--- a/netlify/functions/favorites-remove.ts
+++ b/netlify/functions/favorites-remove.ts
@@ -1,6 +1,6 @@
 import { Handler } from '@netlify/functions';
 import { neon } from '@netlify/neon';
-import jwt from 'jsonwebtoken';
+import * as jwt from 'jsonwebtoken';
 
 const DATABASE_URL = process.env.DATABASE_URL || process.env.NETLIFY_DATABASE_URL || "postgresql://neondb_owner:npg_RaSZ09iyfWAm@ep-winter-recipe-aejsi9db-pooler.c-2.us-east-2.aws.neon.tech/neondb?channel_binding=require&sslmode=require";
 const JWT_SECRET = process.env.JWT_SECRET || 'your-super-secret-jwt-key-change-in-production';
@@ -64,13 +64,13 @@ export const handler: Handler = async (event, context) => {
     console.log(`🗑️ FAVORITES: Removing ${companyId} for user ${decoded.userId}`);
 
     // Remove saved company using snake_case column names
-    const result = await sql.query(`
+    const result = await sql`
       DELETE FROM saved_companies 
-      WHERE user_id = $1 AND company_id = $2
-      RETURNING id;
-    `, [decoded.userId, companyId]);
+      WHERE user_id = ${decoded.userId} AND company_id = ${companyId}
+      RETURNING id
+    `;
 
-    const removedCount = result.rows?.length || 0;
+    const removedCount = result?.length || 0;
     console.log(`✅ FAVORITES: Removed ${removedCount} saved company`);
 
     return {

--- a/netlify/functions/favorites-remove.ts
+++ b/netlify/functions/favorites-remove.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions';
-import { neon } from '@neondatabase/serverless';
+import { neon } from '@netlify/neon';
 import jwt from 'jsonwebtoken';
 
 const DATABASE_URL = process.env.DATABASE_URL || process.env.NETLIFY_DATABASE_URL || "postgresql://neondb_owner:npg_RaSZ09iyfWAm@ep-winter-recipe-aejsi9db-pooler.c-2.us-east-2.aws.neon.tech/neondb?channel_binding=require&sslmode=require";

--- a/netlify/functions/favorites-save.ts
+++ b/netlify/functions/favorites-save.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions';
-import { neon } from '@neondatabase/serverless';
+import { neon } from '@netlify/neon';
 import jwt from 'jsonwebtoken';
 
 const DATABASE_URL = process.env.DATABASE_URL || process.env.NETLIFY_DATABASE_URL || "postgresql://neondb_owner:npg_RaSZ09iyfWAm@ep-winter-recipe-aejsi9db-pooler.c-2.us-east-2.aws.neon.tech/neondb?channel_binding=require&sslmode=require";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.56.4(react@18.3.1))
-      '@neondatabase/serverless':
-        specifier: ^1.0.1
-        version: 1.0.1
       '@netlify/functions':
         specifier: ^4.2.5
         version: 4.2.5(rollup@4.41.0)
@@ -8505,6 +8502,7 @@ snapshots:
     dependencies:
       '@types/node': 22.18.0
       '@types/pg': 8.11.6
+    optional: true
 
   '@netlify/api@14.0.4':
     dependencies:

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,16585 +2,16585 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://minnesotadirectory.com/</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/directory</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/UnitedHealth%20Group%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cargill%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Target%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Saint%20Paul%20Regional%20Water%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/State%20of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/U.S.%20Bancorp</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Best%20Buy%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHS%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/3M%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/General%20Mills%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/C.H.%20Robinson%20Worldwide%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ameriprise%20Financial%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mayo%20Clinic</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ecolab%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Xcel%20Energy%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hormel%20Foods%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Thrivent%20Financial%20For%20Lutherans</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HealthPartners%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Solventum%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fastenal%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fairview%20Health%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Polaris%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/APi%20Group%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Patterson%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/UCare%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/M.%20A.%20Mortenson%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ECMC%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Toro%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Taylor%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Donaldson%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/H.B.%20Fuller%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hmo%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Office%20of%20The%20Board%20of%20Regents</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/nVent%20Electric%20PLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Winnebago%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Land%20O'Lakes%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vista%20Outdoor%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Life%20Time%20Group%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Federated%20Mutual%20Insurance%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Oil%20and%20Gas%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Deluxe%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Graco%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hennepin%20County</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Piper%20Sandler%20Companies</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rosen's%20Diversified%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PVKG%20Intermediate%20Holdings%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AWARE%20INTEGRATED%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Andersen%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dayforce%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Digi-Key%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CWT%20US%20Holding%20I%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sleep%20Number%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ALLETE%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Crystal%20Sugar%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Coborn's%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Medica%20Health%20Plans</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Apogee%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Otter%20Tail%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tennant%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bio-Techne%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KGP%20Telecommunications%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PAS%20PARENT%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Ramsey</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Adolfson%20%26%20Peterson%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Children's%20Health%20Care</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Two%20Harbors%20Investment%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Viking%20Baked%20Goods%20Acquisition%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sun%20Country%20Airlines%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Regions%20Hospital%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Liberty%20Diversified%20International%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cardinal%20Glass%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Regions%20Hospital</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hawkins%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Memorial%20Health%20Care</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minneapolis%20Public%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/University%20Of%20Minnesota%20Physicians</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Saint%20Paul%20Public%20Schools%2C%20District%20625</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Minneapolis</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GDG%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Inspire%20Medical%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Tool%20%26%20Equipment%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SFP%20Holding%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SunOpta%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/McGough%20Construction%20Co.%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MSG%20Nutritional%20Ingredients%20Holding%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mac%20Arthur%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fortra%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anoka-Hennepin%20School%20Dist%20No%2011</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SPS%20Commerce%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jamf%20Holding%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ANI%20Pharmaceuticals%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CJK%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/IP%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Red%20Wing%20Shoe%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CentraCare%20Health%20System</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Presbyterian%20Homes%20And%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pohlad%20Companies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ROSEMOUNT-APPLE%20VALLEY-EAGAN%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Western%20National%20Mutual%20Insurance%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CliftonLarsonAllen%20LLP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ARROWHEAD%20ENGINEERED%20PRODUCTS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20Luke's%20Hospital%20Of%20Duluth</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Churchill%20Companies</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Legacy%20IMBDS%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Miners%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Marvin%20Lumber%20And%20Cedar%20Company%2C%20Llc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Proto%20Labs%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anderson%20Trucking%20Service%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Motors%20Management%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Automotive%20Parts%20Headquarters%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Twin%20City%20Fan%20Companies%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ascentek%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/OneHarris%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jerry's%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Marvin%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20%23279</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Carlson%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Starkey%20Laboratories%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vessco%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cygnus%20Home%20Service%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anoka%2C%20County%20Of</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HEALTHEAST%20ST.%20JOHN'S%20HOSPITAL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Entrust%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cambria%20Company%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Metropolitan%20Airports%20Commission</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/IBB%20Winddown%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Associated%20Milk%20Producers%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Elliott%20Auto%20Supply%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Imagine%20Group%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Great%20River%20Energy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20St%20Louis</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Digi%20International%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ryan%20Companies%20US%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cretex%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crenlo%20Cab%20Products%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ROSEMOUNT-APPLE%20VALLEY-EAGAN%20SCHOOL%20BOARD</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Star%20Mutual%20Insurance%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SOUTH%20WASHINGTON%20COUNTY%20SCHOOLS%20ISD%20833</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Dakota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Marco%20Technologies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Archway%20Marketing%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Original%20Cakerie%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Essentia%20Health</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20535</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tile%20Shop%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KLDiscovery%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mann%20Lake%20Holding%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Superior%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Oxbow%20Industries%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/University%20of%20St.%20Thomas</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Adams%20Publishing%20Group%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ridgeview%20Medical%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hunt%20Electric%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TEAM%20Industries%20Holding%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Milk%20Specialties%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Western%20Consolidated%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midcontinent%20Communications</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Volunteers%20Of%20America%20National%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cold%20Spring%20Granite%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Miller%20Waste%20Mills%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Educational%20Credit%20Management%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Black%20Line%20Group%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Granite%20Falls%20Energy%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gillette%20Children's%20Specialty%20Healthcare</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Trean%20Insurance%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Veit%20%26%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Farmers%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tactile%20Systems%20Technology%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Marsden%20Holding%2C%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Thrifty%20Drug%20Stores%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Washington</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KLN%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plastic%20Products%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Olmsted%20Medical%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mayo%20Clinic%20Health%20System-southeast%20Minnesota%20Region</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Data%20Recognition%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Maple%20Grove%20Hospital%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Rochester</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sezzle%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gardner%20Builders%20Minneapolis%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Olmsted</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20728</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AVI%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southern%20Minnesota%20Municipal%20Power%20Agency</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Connexus%20Energy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Second%20Harvest%20Heartland</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stearns%20Financial%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vomela%20Specialty%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wayzata%20Independent%20School%20District%20284</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Johnson%20Brothers%20Liquor%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Trustone%20Financial%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Arctic%20Glacier%20Usa%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Evereve%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bridgewater%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/IIN%20Holding%20Company%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stan%20Koch%20%26%20Sons%20Trucking%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Champ%20Acquisition%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wells%20Concrete%20Products%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Restaurant%20Technologies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Robbinsdale%20Public%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Affinity%20Plus%20Federal%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/E.%20A.%20Sween%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Healtheast%20Woodwinds%20Hospital</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/INDEPENDENT%20SCHOOL%20DISTRICT%20%23194</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lund%20Food%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Slumberland%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20271</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Total%20Logistic%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/UNIVERSITY%20OF%20MINNESOTA</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mounds%20View%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Regis%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dakota%20Electric%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rahr%20Malting%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ames%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CPM%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hazelden%20Betty%20Ford%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HOM%20Furniture%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20622</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Duininck%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Minneapolis%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Scott</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cirtec%20Medical%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Duluth</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fabcon%20Companies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Loffler%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20No.%20742</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Wright</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20%23624%20(inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kindeva%20Drug%20Delivery%20L.P.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20273</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ziegler%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Eastern%20Carver%20County%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Burnsville%20Eagan%20Savage%20Independent%20School%20District%20191</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Berger%20Transfer%20%26%20Storage%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Diagnostic%20Services%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Workers'%20Compensation%20Reinsurance%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CH%20Holdings%20USA%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Eden%20Prairie%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kowalski%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lakeview%20Memorial%20Hospital%20Association%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lakeshirts%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Running%20Supply%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Carleton%20College</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Innovative%20Office%20Solutions%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Woodwinds%20Health%20Campus</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nott%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cuyuna%20Range%20Hospital%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Accra%20Care%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Farmward%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20623%20(EDU)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20%23834</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/My%20Pillow%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20%23709</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnwest%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cold%20Spring%20Brewing%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Clearfield%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dungarvin%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LAKEVIEW%20MEMORIAL%20HOSPITAL%20ASSOCIATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ecumen</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Turkey%20Valley%20Farms%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Carver</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lutheran%20Social%20Service%20Of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Eden%20Prairie%20Independent%20School%20District%20No.%20272</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wagner%20Holdings%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Perforce%20Software%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SHAKOPEE%20PUBLIC%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20No%2077</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wealth%20Enhancement%20Group%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/INDEPENDENT%20SCHOOL%20DISTRICT%20270</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Prior%20Lake-Savage%20Area%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Young%20Men's%20Christian%20Association%20of%20the%20North</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Bloomington</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lake%20Region%20Healthcare%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ST.%20OLAF%20COLLEGE%20CORP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lakewood%20Health%20System</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GRIFFITHS%20HOLDING%20CORPORATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Knutson%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Short-Elliott-Hendrickson%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/East%20Central%20Energy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sherburne%2C%20County%20Of%20(inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hammel%2C%20Green%20And%20Abrahamson%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Activar%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Highwater%20Ethanol%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Macalester%20College</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Varde%20Partners%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Wells%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20%23%20152</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Blue%20Earth</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/University%20Financial%20Corp.%2C%20GBC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Farmington%20Area%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MAGNIFI%20FINANCIAL%20FOUNDATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lifecore%20Biomedical%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nortech%20Systems%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Merchants%20Financial%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Surmodics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midcontinent%20Media%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/W.%20D.%20Larson%20Companies%20LTD.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Welia%20Health</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wright-Hennepin%20Cooperative%20Electric%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/University%20Of%20Northwestern%20-%20St.%20Paul</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Brainerd%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Choreo%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mankato%20Rehabilitation%20Center%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/G.G.%20McGuiggan%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crow%20Wing%20County</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Corporate%20Technologies%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Trustees%20Of%20The%20Hamline%20University%20Of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Battmann%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Blaze%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Otter%20Tail</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Centennial%20School%20District%2012</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20Louis%20Park%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Novel%20Energy%20Solutions%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Thrivent%20Charitable%20Impact%20%26%20Investing</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Saint%20Paul%20Foundation%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Spring%20Lake%20Park%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Itasca%2C%20County%20Of%20(inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Concordia%20University%2C%20St.%20Paul</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bernatello's%20Pizza%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St%20Michael-Albertville%20School%20District%20%23885</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Trafera%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southern%20Minnesota%20Beet%20Sugar%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Winona%20Health%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lake%20Country%20Power</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Business%20Forms%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/River%20Country%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ironmark%20Building%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Valley%20Electric%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/John%20Henry%20Foster%20Minnesota%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Insulation%20Distributors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Star%20Tribune%20Media%20Company%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Shakopee%20Mdewakanton%20Sioux%20Community</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20McKnight%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Washington%20County%20IND%20School%20DIST%20831</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wagner%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Grain%20Millers%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Riverview%2C%20LLP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rockler%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Innovance%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ceres%20Global%20AG%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20%23492</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vivacity%20Tech%20PBC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Satellite%20Shelters%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lindstrom%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dorsey%20%26%20Whitney%20LLP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20197</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Walser%20Automotive%20Group%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Maple%20Grove%2C%20City%20Of%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BGI%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Omni%20Workspace%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Intermediate%20District%20%23287</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wunderlich-Malec%20Engineering%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hutchinson%20Area%20Health%20Care</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MidCountry%20Acquisition%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Domaille%20Holdco%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20283</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Self%20Esteem%20Brands%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Agmotion%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Zinpro%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Upper%20Midwest%20Organ%20Procurement%20Organization%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Kandiyohi</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Road%20Machinery%20%26%20Supplies%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plainview%20Milk%20Products%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/J%20%26%20B%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Brooklyn%20Park</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/Leech%20Lake%20Reservation%20Business%20Committee%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Maxxon%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/Leech%20Lake%20Reservation%20Business%20Committee%20Inc</loc>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SKYLINE%20DISPLAYS%20HOLDINGS%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Metro%20Sales%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wenger%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Apex%20International%20Mfg.%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/J.%20H.%20Larson%20Electrical%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tony%20Downs%20Foods%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vinco%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Goodin%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20%23877%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jacobs%20Industries%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Richfield%20Independent%20School%20District%20280</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Prinsburg%20Farmers%20Co-Op</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Old%20Dutch%20Foods%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Twins%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mississippi%20Welders%20Supply%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mendota%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Baptist%20Homes%20Of%20The%20Midwest</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20No%20761</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Design%20Ready%20Controls%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Room%20%26%20Board%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Culligan%20Soft%20Water%20Service%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Saint%20Mary's%20University%20Of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Data%20Sales%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Risk%20Partners%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pediatric%20Home%20Respiratory%20Services%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Force%20America%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20States%20Distilled%20Products%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Aitkin%20Community%20Hospital%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lifeworks%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Horton%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Power%20Play%20Marketing%20Group%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Saint%20Cloud</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hubbard%20Broadcasting%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ergotron%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Advanced%20Web%20Technologies%20Illinois%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Woodbury</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MNGI%20Digestive%20Health%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Banner%20Engineering%20International%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Torgerson%20Properties%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Egan%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Margaret%20A.%20Cargill%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Standard%20Iron%20%26%20Wire%20Works%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Goodhue</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BEMIDJI%20AREA%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SPS%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quality%20Bicycle%20Products%2C%20GBC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Historical%20Society</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dooley's%20Petroleum%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20Catherine%20University</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crow%20Wing%20Cooperative%20Power%20And%20Light%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Edina</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/IntriCon%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midwest%20Veterinary%20Supply%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Chisago</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Plymouth</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pan-O-Gold%20Baking%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gustavus%20Adolphus%20College</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cemstone%20Products%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pheasants%20Forever%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ceridian%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Beltrami</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Belair%20Builders%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Astera%20Health</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cambridge-Isanti%20Public%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Douglas%20Machine%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Teamsters%20Local%202000</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/J%20%26%20R%20Schugel%20Trucking%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SSR%20PROPERTIES%20COMPANY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Christensen%20Farms%20%26%20Feedlots%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/STEIN%20HOLDINGS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Barr%20Engineering%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Clay</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Augeo%20Affinity%20Marketing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Power%2FMation%20Division%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Russ%20Davis%20Wholesale%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20St%20Louis%20Park</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mcneilus%20Steel%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kurt%20Manufacturing%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dezurik%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Lakeville</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Concordia%20College%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Technologies%20International%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Burnsville</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northwest%20Asphalt%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Calabrio%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ABC%20Bus%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bethel%20University</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Benedictine%20Health%20System</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hartfiel%20Automation%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Schoeneckers%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Saint%20John's%20University</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Willmar%20School%20District%20347</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Otto%20Bremer%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Apex%20Water%20and%20Process%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dakota%20County%20Community%20Development%20Agency</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Opus%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Think%20Mutual%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pro-ag%20Farmers%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MiEnergy%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bluum%20of%20Minnesota%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Winmark%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Grand%20Rapids%20Independent%20School%20District%20No%20318</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northeast%20Metropolitan%20Intermediate%20School%20District%20916</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nexus%20Family%20Healing</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Alexandria%20Extrusion%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Glencoe%20Regional%20Health%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20Schl%20Dist%2031</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pioneer%20Power%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BLST%20Holding%20Company%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hastings%20Independent%20School%20District%20200</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Three%20Rivers%20Park%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northfield%20Public%20Schools%2C%20ISD%20%23659</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nextera%20Packaging%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ALEXANDRIA%20SCHOOL%20DISTRICT%20206</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20Vision%20Co-Op</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Paul%20Bunyan%20Rural%20Telephone%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Eden%20Prairie</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sauk%20Rapids-Rice%20Independent%20School%20District%2047</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Minnetonka</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Eagan</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Corval%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Teen%20Challenge%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/College%20of%20St.%20Scholastica%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Twin%20City%20Concrete%20Products%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Catholic%20Community%20Foundation%20of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/215%20Holding%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Herc-U-Lift%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Carlton</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%200656</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Everidge%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20Croix%20Hospice%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Monticello%20Independent%20School%20District%20%23882</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Augsburg%20University</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Waconia%20Independent%20School%20District%20110</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Forstrom%20Bancorporation%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dart%20Holding%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lube-Tech%20%26%20Partners%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Polk</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SIGN-ZONE%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fagen%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bay%20%26%20Bay%20Transfer%20Co.%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Teamsters%20Local%20346%20Health%20Fund</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Productivity%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Smead%20Manufacturing%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fraser%20Child%20And%20Family%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Douglas</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/EPROMOS%20PROMOTIONAL%20PRODUCTS%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Columbia%20Heights%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Planned%20Parenthood%20North%20Central%20States</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ever-Green%20Energy%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Blaine</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nuvera%20Communications%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Olympic%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Morrison</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stearns%20Cooperative%20Electric%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Frauenshuh%20Hospitality%20Group%20Of%20Minnesota%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bongards'%20Creameries</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20659</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Becker</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Catholic%20Charities%20Of%20The%20Archdiocese%20Of%20St%20Paul%20And%20Minneapolis</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20241</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/INVER%20GROVE%20HEIGHTS%20COMMUNITY%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Farmers%20Union%20Industries%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SCOTT%20RICE%20%26%20LE%20SUEUR%20COS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Natural%20American%20Foods%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Bankers'%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hamline%20University</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Eddie%20M's%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/EVENTIDE%20LIVING%20CENTER</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Equus%20Computer%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/National%20Marrow%20Donor%20Program</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Feed%20My%20Starving%20Children</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Community%20Memorial%20Hospital%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lifespark%20Group%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Isanti</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Leeann%20Chin%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Production%20Automation%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Austin%20Utilities</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20518</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wilson%20Tool%20International%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Moorhead</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PARTNERS%20IN%20COMMUNITY%20SUPPORTS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Coon%20Rapids</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Knobelsdorff%20Electric%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Goodwill%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Minneapolis%20Society%20of%20Fine%20Arts</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Transitions%20Charter%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Knute%20Nelson</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nicollet%20County</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Shakopee</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Bernard%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sartell%20St%20Stephen%20School%20District%20748</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Riverview%20Healthcare%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/L%20and%20M%20Supply%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NA%20Corp</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tradehome%20Shoe%20Stores%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Beltrami%20Electric%20Co-Op%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/California%20Overland%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BIG%20LAKE%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Winona</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mitchell%20Hamline%20School%20Of%20Law</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FRIDLEY%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20McLeod</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Canterbury%20Park%20Holding%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/District%20Energy%20St.%20Paul%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Critical%20Care%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Shaw-Lundquist%20Associates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ALIGHT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MAHTOMEDI%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Walker%20Art%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Members%20Cooperative%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Forklifts%20of%20Minnnesota%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/College%20Of%20Saint%20Benedict</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Mankato</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Freeborn%20Mower%20Electric%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Premier%20Electrical%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Chaska</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Pine</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tools%20AcquisitionCo%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Blu%20Dot%20Design%20%26%20Manufacturing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/National%20Checking%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gopher%20Resource%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Blake%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Sierra%20Company%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Chisago%20Lakes%20Area%20Schools%2C%20ISD%202144</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northwest%20Grains%20International%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Consulting%20Services%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mille%20Lacs%20Health%20System</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Steele</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lake%20Region%20Electric%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PRINCETON%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Apple%20Valley</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LifeCare%20Medical%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anchor%20Paper%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/INDEPENDENT%20SCHOOL%20DISTRICT%20NO.%20278%20COUNTY%20OF%20HENNEPIN</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SUNation%20Energy%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gephart%20Electric%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SitelogIQ%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Meyers%20Printing%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/Ideal%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ideal%20Credit%20Union%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/Ideal%20Credit%20Union</loc>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GREATER%20TWIN%20CITIES%20UNITED%20WAY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Planned%20Parenthood%20Minnesota%2C%20North%20Dakota%2C%20South%20Dakota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Benton</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dominium%20Management%20Services%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/People's%20Cooperative%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gartner%20Refrigeration%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/King%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Special%20School%20District%20No%206</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/People%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dunwoody%20College%20Of%20Technology</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Electromed%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Le%20Sueur</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cottage%20Grove%2C%20City%20Of%20(inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hubbard%2C%20County%20of%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20USA%20Group%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bolton%20%26%20Menk%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dey%20Appliance%20Service%20Co</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Blue%20Earth-Nicolett-Faribault%20Cooperative%20Electric%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Centra%20Ventures%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Premier%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Inver%20Grove%20Heights</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bowman%20and%20Brooke%20LLP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20%26%20County%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Senior%20Care%20Communities%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Amherst%20H.%20Wilder%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Spirit%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bartley%20Lindsey%20Company%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Detroit%20Lakes%20Public%20Schools%20District%20%2322</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CCM%20Health</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Deerwood%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ShoreView%20Industries%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Arctic%20Wolf%20Networks%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Coffee%20%26%20Bagel%20Brands</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Conklin%20Company%20Partners%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stevens%20Community%20Medical%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Winona%20Area%20Independent%20School%20District%20861</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/McDowall%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Weis%20Builders%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Twin%20Cities%20Public%20Television%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HMN%20Financial%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Richfield</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WSB%20%26%20Associates%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TS2%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Melrose%20Area%20Hospital</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Marshall%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CVRx%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Breck%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nobles%20County</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HOMESTEAD%20ROAD</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Circuit%20Check%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LVC%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Baldwin%20Supply%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Driessen%20Water%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/S.J.%20Louis%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gemini%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RMS%20Energy%20Co%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minco%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Prinsco%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Arrowhead%20Economic%20Opportunity%20Agency%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Outdoor%20Living%20Supply%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Velosity%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Mille%20Lacs</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Winona%20Area%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Goodman%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20Horizon%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southwest%20%26%20West%20Central%20Service%20Cooperatives</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Priority%20Envelope%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/W.%20L.%20Hall%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Viking%20Coca-Cola%20Bottling%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Duke%20Financial%20Group%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/E.I.%20Microcircuits%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Log%20House%20Foods%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Branch%20Area%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Massman%20Automation%20Designs%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lakeland%20Engineering%20Equipment%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Retail%20Tech%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Brown</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pace%20Electronics%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Academy%20Of%20Neurology</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Roseville%2C%20City%20Of%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DecoPac%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Contours%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Le%20Sueur%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bachman's%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Brooklyn%20Center%20Independent%20School%20District%20286</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northwest%20Respiratory%20Services%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BSA%20WORLDWIDE%20HOLDINGS%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/IdentiSys%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WSB%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Umi%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mackin%20Book%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/West%20Central%20Ag%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Indelco%20Plastics%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Minnesota%20Diagnostic%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Agribank%2C%20FCB</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Catallia%20Mexican%20Foods%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Equipoise%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20544</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/I%20SPACE%20FURNITURE%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20AG%20Power%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cloquet%20Public%20Schools%20ISD%20%2394</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sico%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Riverside%20Electronics%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/C.S.%20McCrossan%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Timesavers%20Acquisition%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Detector%20Electronics%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Spee%20Dee%20Delivery%20Service%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20Of%20Mcleod%2C%20Ind%20School%20Dist%20423</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/West%20Side%20Community%20Health%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Todd</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Prairie%20Island%20Indian%20Community</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midwest%20Radiology%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Evangelical%20Free%20Church%20of%20America</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Elevator%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Golden%20Valley%2C%20City%20Of%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Border%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northcott%20Hospitality%20International%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Region%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Park%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Schwab-Vollhaber-Lubratt%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Delkor%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fairview%20Clinics</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/U.%20S.%20Internet%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20John%20Roberts%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/W.P.%20%26%20R.S.%20Mars%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Hospital%20District%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Saint%20Louis%20County%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nuway%20House%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pdhc%2C%20Ltd</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RED%20WING%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kids%20In%20Need%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Country%20Business%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/First%20Bemidji%20Holding%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WESTONKA%20PUBLIC%20SCHOOLS%20DISTRICT%20277</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ISC%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pinnacle%20Climate%20Technologies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Alvin%20E.%20Benike%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BECKER%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/THE%20FIRST%20DISTRICT%20ASSOCIATION%20(FDA)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ST.%20PAUL%20ACADEMY%20AND%20SUMMIT%20SCHOOL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Farmers%20State%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Waymouth%20Farms%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Steele-Waseca%20Cooperative%20Electric</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Warners'%20Stellian%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Brin%20Glass%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mankato%20Clinic%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crystal%20Valley%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gerten%20Greenhouses%20%26%20Garden%20Center%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Twin%20City%20Die%20Castings%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Applied%20Power%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Horwitz%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SHL%20US%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Minnesota%20Orchestral%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Marshall%20Municipal%20Utilities%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Engage%20Technologies%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/VESSCO%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bolger%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ratner%20Steel%20Supply%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lake%20Air%20Products%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CENTRACARE%20PROVIDER%20SERVICES%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Certified%20Power%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Park%20Construction%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fairview%20Homecare%20%26%20Hospice%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FAST%20GLOBAL%20SOLUTIONS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plymold%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Taher%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AVEKA%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Garden%20Valley%20Telephone%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sand%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Arrow%20Tank%20And%20Engineering%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Muska%20Electric%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Twin%20Cities%20Habitat%20For%20Humanity%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MOUNT%20OLIVET%20ROLLING%20ACRES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Haldeman-Homme%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GLS%20Companies</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crystal%20Distribution%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Chemstar%20Products%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nuss%20Truck%20Group%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Bush%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Yellow%20Medicine</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dayton%20Rogers%20Manufacturing%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Redwood</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Meeker</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Federated%20Rural%20Electric%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hill%20Museum%20%26%20Manuscript%20Library</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ABRAHAM%20TECHNICAL%20SERVICES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Arkray%20America%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/All%20Flex%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Finlayson%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Maplewood</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Delano%20Independent%20School%20District%20879</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fraser</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/South%20Metro%20Human%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rasmussen%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Walker%20Ban%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Meyer%20Contracting%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Fillmore</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Intermediate%20School%20District%20%23917</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MinMor%20Industries%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mackay%20Mitchell%20Envelope%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Topline%20Federal%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ISD%20423%20HUTCHINSON</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Collins%20Electrical%20Construction%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Episcopal%20Homes%20Of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Process%20Displays%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Perham%20Hospital%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hammer%20Residences%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Direct%20Source%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pioneer%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Renville</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Braun%20Intertec%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midwest%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Greystone%20Construction%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Consolidated%20Telephone%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Frattalone%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wheaton-Dumont%20Coop%20Elevator</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Landscape%20Structures%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20Ulm%20Independent%20School%20District%2088</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rocori%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ideal%20System%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Metropolitan%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PROJECT%20FOR%20PRIDE%20IN%20LIVING%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bethesda</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sportsman's%20Guide%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Hormel%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/VOA%20CARE%20CENTERS%2C%20MINNESOTA</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Open%20Access%20Technology%20International%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Little%20Falls%20Public%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Essentia%20Health%20Moose%20Lake</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hirshfield's%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sibley%20County</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central-McGowan%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Martin</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20West%20Saint%20Paul</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HABITAT%20FOR%20HUMANITY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20No.%20413</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bedford%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Cook</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Scholarship%20America%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TRADITION%20BANCSHARES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Fridley</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minneapolis%20Jewish%20Federation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Studios-Digital%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Lake</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20The%20Housing%20and%20Redevelopment%20Authority%20of%20The%20City%20of%20Saint%20Paul</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Schoenfelder%20Renovations%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Millerbernd%20Manufacturing%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gowan%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hole%20Products%20Limited%20Liability%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/M.%20G.%20McGrath%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Brooklyn%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Anoka</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Flagship%20Financial%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Summit%20Mortgage%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Satellite%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Heartland%20Equity%20Partners%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Energy%20Management%20Collaborative%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PARENTS%20IN%20COMMUNITY%20ACTION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nahan%20Printing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Distribution%20Alternatives%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Wabasha</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Delta%20Dental%20of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ST.%20PETER%20PUBLIC%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Heartland%20Agriculture%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Demmer%20Investments%20IV%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20531</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Volunteers%20of%20America%20Care%20Facilities</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mercy%20Home%20Health%20Agency</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Education%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HIBBING%20PUBLIC%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Merchant%20%26%20Gould%20P.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Swanson%20%26%20Youngdale%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lendway%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Apollo%20Technology%20Group%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Park%20Rapids%20Area%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20South%20Saint%20Paul</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Scale%20Holding%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nystrom%20%26%20Associates%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SFM%20Mutual%20Insurance%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Guthrie%20Theater%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/THINK%20SMALL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tri-State%20Drilling%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LHB%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Beckhoff%20Automation%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Heritage%20Bancshares%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Avivo</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Western%20Lake%20Superior%20Sanitary%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Builtrite%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Owatonna</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wild%20Rice%20Electric%20Cooperative%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Grand%20Rapids</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bigos%20Management%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Shattuck-St.%20Mary's%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Aeon</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/InCompass%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Oakdale</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Scherer%20Bros.%20Lumber%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Volunteers%20Of%20America%20Of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Community%20Reinvestment%20Fund%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Equus%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Kanabec</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Red%20Wing</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Elk%20River</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kasson-Mantorville%20Ind%20SD%20204</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rice%20Lake%20Contracting%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pipestone%20County%20Medical%20Center%20%26%20Family%20Clinic%20Avera</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Elim%20Care%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20Of%20New%20Brighton%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Community%20Action%20Partnership%20Of%20Ramsey%20And%20Washington%20Counties</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Central%20University</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hanson%20Communications%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/Enterprise-CP.LLC</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/Eagle%20Brook%20Church%20of%20White%20Bear%20Lake%2C%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Building%20Fasteners%20of%20Minnesota%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/Eagle%20Brook%20Church%20of%20White%20Bear%20Lake%2C%20Minnesota</loc>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/Enterprise-CP.LLC</loc>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Asset%20Marketing%20Services%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Allegis%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Metroplains%20Properties%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mastec%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Rosemount</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Chandler%20Exhibits%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/International%20Falls%20Memorial%20Hospital%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/College%20Possible</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vermillion%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cortec%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northwestern%20Health%20Sciences%20University</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Waseca</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Hopkins</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Lyon</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/I%20%26%20S%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bethany%20Lutheran%20College%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nonin%20Medical%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Shoreview</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sela%20Roofing%20and%20Remodeling%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hank's%20Specialties%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jordan%20School%20District%20717</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dassel-Cokato%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Community%20Action%20Partnership%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Replenex%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Platinum%20Bancorp%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cass%20Lake%20Bena%20Independent%20School%20District%20115%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Reo%20Plastics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Roseau</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Abdo%20Investments%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Guardian%20Energy%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20No.%202752</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stewartville%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Deceased%20Credit%20Management%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WILKIN%20COUNTY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Faribault%2C%20City%20Of%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mora%20Independent%20School%20District%20%23332</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Annandale%20Independent%20School%20District%20876</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Runestone%20Electric%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Prior%20Lake</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20%23829</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NORTHEAST%20SECURITIES%20CORPORATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minneapolis%20College%20Of%20Art%20%26%20Design</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Groves%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hermantown%20Independent%20School%20District%20700</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SANUWAVE%20Health%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Redstone%20American%20Grill%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Savage</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/M.C.I.%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dynatronics%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mille%20Lacs%20Energy%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20%23745</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ortonville%20Area%20Health%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Houston</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Ramsey</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gagnon%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Solbar%20USA</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Stillwater</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crown%20College</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rockford%20Independent%20School%20District%20883</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hiawatha%20Leadership%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MINNESOTA%20VALLEY%20TRANSIT%20AUTHORITY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Hibbing</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Austin</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HOPE%20ACADEMY%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Koochiching</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Border%20Foods%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Andover</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Advanced%20Process%20Technologies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ALP%20Utilities</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Financiere%20Lully%20F%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southwest%20Metro%20Intermediate%20District%20%23288</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CWMF%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/East%20Grand%20Forks%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Itasca-Mantrap%20Co-op.%20Electrical%20Ass'n</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHILDREN'S%20CLINIC%20NETWORK</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Port%20Authority%20of%20The%20City%20of%20Saint%20Paul</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Faribault</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Meeker%20Cooperative%20Light%20%26%20Power%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nu-Tek%20Food%20Science%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Summit%20360%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Maud%20Borup%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ely-Bloomenson%20Community%20Hospital</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RISE%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GHR%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mental%20Health%20Resources%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Center%20For%20Victims%20Of%20Torture</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Veterinary%20Pharmacy%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Innovize%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Thief%20River%20Falls%20School%20District%20564</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Valley%20Action%20Council%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Milaca%20Public%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jefferson%20Capital%20Systems%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PARK%20NICOLLET%20HEALTH%20CARE%20PROD.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Peregrine%20Capital%20Management%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Flexible%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dakota%20Communities%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Apple%20Nine%20Hospitality%20Management%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tri-valley%20Opportunity%20Council%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Walker%20Methodist</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GATO%20HOLDINGS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Masonic%20Home%20Care%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DCI%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20704</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Knowlan's%20Super%20Markets%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Land%20O'Lakes%20Venture37</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/I.%20C.%20System%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ag%20Plus%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/First%20Children's%20Finance</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20Cloud%20Refrigeration%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CENTRAL%20MINNESOTA%20%20COMMUNITY%20FOUNDATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PC%20Parts%20Plus%20L.%20L.%20C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Master%20Electric%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/JONNY%20POPS%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hiawatha%20Academies</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Commonbond%20Communities</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Foley%20Independent%20School%20District%20%2351</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Bank%20of%20Elk%20River</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Swift</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Accessible%20Space%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Excel%20Plastics%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Final%20Coat%20Painting%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St%20Anthony%20New%20Brighton%20School%20District%20282</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pequot%20Lakes%20Independent%20School%20District%20186</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Houston%20Public%20Schools%20ISD%20%23294</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Specialty%20Mfg.%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20London-Spicer%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wayne%20Transports%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Intek%20Plastics%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Andersen%20Windows%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Avera%20Granite%20Falls</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mayo%20Clinic%20Employees%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CIty%20of%20Willmar</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Becker</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mid-County%20Coop</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20465</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WINDOM%20AREA%20HEALTH%20AUXILIARY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Parasole%20Restaurant%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Federated%20Co-Ops%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Artspace%20Projects%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20David's%20Center%20Child%20%26%20Family%20Development</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Rogers</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minneapolis%20Clinic%20Of%20Neurology%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Apothecary%20Products%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Science%20Museum%20of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ESG%20Architecture%20%26%20Design%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Virgniia%20Minnesota%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/J.%20Becher%20%26%20Assoc.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Governmental%20and%20Educational%20Assistance%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FORSMAN%20FARMS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GPM%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gladwin%20Machinery%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Omnetics%20Connector%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Atomic%20Data%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ST.%20JOSEPH%20BANCSHARES%20ACQUISITIONS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Aspen%20Waste%20Systems%20Of%20Minnesota%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Minnesota%20Mental%20Health%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Saint%20Therese%20of%20New%20Hope</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/IDC%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Discount%20Steel%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Shore%20Financial%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CEDAR%20CREEK%20ENERGY%20CORPORATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Columbia%20Heights</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Spring%20Thymes%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wescom%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Carisch%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lyons%20Trading%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Watonwan</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lake%20Superior%20School%20District%20%23381</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Alliance%20Financial%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Enhanced%20Information%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Hastings</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20Pet%20Partners%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Providers%20Choice%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Apple%20Tree%20Dental</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Winona</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Corner%20Home%20Medical%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/States%20Manufacturing%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Lutheran%20Home%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Glenwood%20State%20Bank%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/S.A.V.%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Cottonwood</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/South%20Central%20Electric%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20Ulm%2C%20City%20Of%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/H.%20M.%20Cragg%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wholesale%20Produce%20Supply%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CANVAS%20HEALTH%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Opportunity%20Partners%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Leedstone%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Meritex%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Geotek%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nei%20Electric%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Poly-Tex%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/General%20Office%20Products%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Colwell%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Providence%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rao%20Manufacturing%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Weatherization%20Specialists</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Marshall%2C%20City%20Of%20(inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Computer%20Integration%20Technologies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Container%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Friesen's%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Agralite%20Electric%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Twin%20City%20Hardware%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lindar%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnewaska%20Area%20Schools%20%232149</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20Fashion%20Pork%2C%20LLP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Watertown-Mayer%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20578</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rapid%20Packaging%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Champlin</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Assistance%20Council%20For%20Veterans</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Preferred%20Credit%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NORTHERN%20WHOLESALE%20SUPPLY%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Qa1%20Precision%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ellingson%20Drainage%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PCS%20FOR%20PEOPLE</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Pennington</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quality%20Pork%20Processors%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Brown%20-%20Wilbert%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mount%20Olivet%20Careview%20Home</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Orton%20Motor%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20No%202859</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Now%20Micro%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Alatus%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DILWORTH-GLYNDON-FELTON%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ovative%20Group%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bevsource%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jasper%20Engineering%20%26%20Equipment%20Company%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cavity%20Free%20Kids</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Borealis%20Philanthropy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Montevideo%20School%20District%20%23129</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Virginia</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SouthPoint%20Financial%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sauk%20Centre%20Independent%20School%20District%20743</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Thomas%20Allen%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Herregan%20Distributors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Furniture%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Micro%20Control%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TRI-CITY%20UNITED</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sagitec%20Solutions%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnehaha%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Roofing%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NVE%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Evco%20Petroleum%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nasseff%20Plumbing%20%26%20Heating%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Great%20Clips%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Timberland%20Partners%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wold%20Architects%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AMERI%20FINANCIAL%20GROUP%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Buffalo</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Valley%20Cooperative%20Light%20and%20Power%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Farmington</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LAKE%20ELMO%20BANCSHARES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/COUNTY%20OF%20MARSHALL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Associated%20Mechanical%20Contractors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CALHOUN%20MANAGEMENT%20CO.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pine%20Island%20ISD%20255</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FFS%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ulland%20Brothers%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Chanhassen</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Murphy%20Warehouse%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nystrom%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bernick's%20Production%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Stevens</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Community%20Action%20Partnership%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Liqtech%20International%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PCIRoads%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GLACIAL%20RIDGE%20HEALTH%20SYSTEM</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wieser%20Brothers%20General%20Contractor%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Waseca%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sons%20of%20Norway</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Living%20Well%20Disability%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Zumbrota-Mazeppa%20School%20District%202805</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vernon%20Center%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Profinium%20Financial%20Holdings%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nath%20Companies%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Design%20Electric%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Weelborg%20Ford%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Trystar%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/RW%20National%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/Anderson%20Chemical%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/A%20Better%20Way%20to%20Build%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Progressive%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/A%20Better%20Way%20to%20Build%20LLC</loc>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/RW%20National%20Holdings%2C%20LLC</loc>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/Anderson%20Chemical%20Company</loc>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Man%20Cave%20Foods%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Concord%20USA%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Blaine%20Brothers%20Maintenance%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northbridge%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sparboe%20Farms%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PCC%20Candy%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AAA%20Minneapolis</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Citrus%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Construction%20Materials%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northland%20Process%20Piping%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/E%20%26%20O%20Tool%20%26%20Plastics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dynamic%20Air%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Business%20Mail%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Computype%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Wind%20Test%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nor-Son%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Buerkle%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Adara%20Home%20Health%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Summit%20Brewing%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Interstate%20Improvement%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Valley%20Testing%20Laboratories%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20American%20Registry%20of%20Radiologic%20Technologists</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rotochopper%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gradient%20Financial%20Group%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Homecrest%20Outdoor%20Living%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Crystal</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Carl%20Bolander%20%26%20Sons%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Marcus%20Construction%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Youngstedt%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Conleasco%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tandem%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Davanni's%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Whitebox%20Advisors%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Redwood%20Financial%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CROOKSTON%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kgpco%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sowles%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Goebel%20Fixture%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Microbiologics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Total%20Expert%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kath%20Fuel%20Oil%20Service%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lundell%20Manufacturing%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cool%20Air%20Mechanical%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Analog%20Technologies%2C%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stoneridge%20Software%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Haworth%20Marketing%20%26%20Media%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Drywall%20Supply%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sabrosura%20Foods%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Concept%20Machine%20Tool%20Sales%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mongolian%20Operating%20Company%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bureau%20of%20Engraving%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Foss%20Swim%20School%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/UHL%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stylmark%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Reichel%20Foods%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Engineered%20Products%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midwest%20Overhead%20Crane%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Shaw%20Lumber%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fluid%20Interiors%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Focus%20Financial%20Network%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Toll%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FPH%20MAG%20MANAGEMENT%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Brown%20%26%20Bigelow%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Farmers%20Co-operative%20Oil%20Company%20Of%20Renville%2C%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Noran%20Neurological%20Clinic%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Masterson%20Staffing%20Solutions</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/THL%20Agiliti%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MICHAUD%2C%20COOLEY%2C%20ERICKSON%20%26%20ASSOCIATES%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Center%20for%20Energy%20and%20Environment.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/R%20%26%20R%20Transportation%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Retail%20Construction%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ZUMBRO%20VALLEY%20HEALTH%20CENTER</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Felling%20Trailers%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Climate%20By%20Design%20International%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Delphix%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Allianz%20Life%20Insurance%20Company%20of%20Missouri</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Istate%20Truck%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Land%20Title%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CITIZENS%20BANCORPORATION%20OF%20NEW%20ULM%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/OSI%20Environmental%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kendell%20Doors%20%26%20Hardware%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Centra%20Sota%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kandiyohi%20Power%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Molin%20Concrete%20Products%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Shapco%20Printing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Converters%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nextera%20Analytics%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fagron%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northfield%20Hospital%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Birchwood%20Laboratories%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ritchie%20Engineering%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FAIRVIEW%20HOSPITAL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FRASER%20STEEL%20COMPANY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/STAR%20ENERGY%20SERVICES%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nova-Tech%20Engineering%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KIMBERLY%20MEADOWS%2C%20LLLP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Great%20Northern%20Equipment%20Distributing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Monticello</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anderson%20Crane%20Rubber%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Coordinated%20Business%20Systems%2C%20Ltd.%20Of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Industrial%20Lubricant%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Milastar%20Corp</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Greiner%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Solidify%20Manufacturing%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Triangle%20Warehouse%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/General%20Pattern%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Belle%20Plaine%20Independent%20School%20District%20716</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/General%20Security%20Services%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Castlelake%2C%20L.P.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Alpha%20Video%20and%20Audio%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Waytek%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Opus%20Holding%2C%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Prophet%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Triple%20Crown%20Nutrition%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Chippewa%20Valley%20Agrafuels%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Star%20Exhibits%20%26%20Environments%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Intercomp%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Parallel%20Technologies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/REVO%20HEALTH%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Toyota-lift%20of%20Minnesota%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mounds%20Park%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Renovation%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Johnson%20Memorial%20Health%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northland%20Aluminum%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Thern%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Douglas%20Scientific%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rachel%20Contracting%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Herold%20Precision%20Metals%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/EOSIS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Al-Corn%20Clean%20Fuel%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Motion%20Tech%20Automation%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Hutchinson</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Autism%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LAKE%20VIEW%20MEMORIAL%20HOSPITAL%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Advisornet%20Financial%20and%20Secure%20Networks</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CATHOLIC%20CHARITIES%20OF%20THE%20DIOCESE%20OF%20ST.%20CLOUD</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/THREE%20LINKS%20HEALTH%20SERVICES</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bethany%20Fellowship%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RJM%20CONSTRUCTION%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/McC%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Howard%20Lake-Waverly-Wi</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Woodland%20Centers</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Master%20Technology%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cat%20Pumps%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cotter%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LINN%20RETAIL%20CENTERS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ban-Koe%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jordan%20Independent%20School%20District%20%23717</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nexen%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jonti-Craft%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Homestead%20at%20Anoka%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/B.T.W.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/White%20Bear%20Lake%20City%20of</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Staples%20Motley%20ISD%20%232170</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BANCOMMUNITY%20SERVICE%20CORPORATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bauer%20Welding%20and%20Metal%20Fabricators%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Form-A-Feed%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Public%20Media%20Group</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Pride%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Humanities%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Metropolitan%20Area%20Agency%20On%20Aging%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Innovative%20Certified%20Technical%20Plating%2C%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CSM%20CORPORATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bermo%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Alternative%20Business%20Furniture%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Homes%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Heritage%20Holding%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Frana%20Companies%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SAM%20HPRP%20CHEMICALS%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnetronix%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ByteSpeed%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Lino%20Lakes</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fun.com%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jeremiah%20Program</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Farnam%20Street%20Financial%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Impact%20Mailing%20of%20Minnesota%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Soybean%20Processors</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cal-tex%20Electric%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Consolidated%20Container%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/About%20Healthcare%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Windom%20Public%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Careen%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/America's%20TPA%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Worthington</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fullerton%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Fish%20Guys%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Assurance%20Mfg.%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Central%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/EASY%20AUTOMATION%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MAC%20Management%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tilsner%20Carton%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Trend%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Residential%20Services%20Of%20Northeastern%20Minnesota%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St%20David's%20School%20For%20Child%20Development%20%26%20Family%20Services%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/JEM%20Technical%20Marketing%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Logistics%20Services%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mayflower%20Distributing%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Foundation%20For%20Healthcare%20Continuums%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Legacy%20Building%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/rms%20Surgical</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cameron's%20Coffee%20and%20Distribution%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Winsted%20Company%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wanner%20Engineering%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Astrup%20Drug%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Farmers%20Co-operative%20Assn%20Of%20Milroy%20(inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Empirehouse%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lieberman%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Luminate%20Home%20Loans%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/IMAGETREND%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sheehy%20Construction%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Versare%20Solutions%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Primera%20Technology%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Geneva%20Capital%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Albert%20Lea</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SiteImprove%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Fergus%20Falls</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bernard%20J.%20Mulcahy%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Space150%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bell%20International%20Laboratories%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Elder-Jones%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HEARTH%20N%20HOME</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Advanced%20Service%20Management%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FABCON%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northstar%20Systembuilt%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Landscape%20Arboretum%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/V3%20SPORTS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Factory%20Sales%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Human%20Development%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/A.%20H.%20Hermel%20Candy%20%26%20Tobacco%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cassia%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Seacole-CRC%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Harmony%20Enterprises%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Rapat%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ABM%20Equipment%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fredrikson%20%26%20Byron%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/King%20Technology%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/McLeod%20Cooperative%20Power%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Todd%20Wadena%20Electric%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Agility%20Engineering%20and%20Manufacturing%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Twin%20Cities%20Automotive%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mrs.%20Gerry's%20Kitchen%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Augustana%20Care</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Air%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ARTHUR%2C%20CHAPMAN%2C%20KETTERING%2C%20SMETAK%20%26%20PIKALA%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hennepin%20Technical%20College</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Harland%20Medical%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Avionte%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Trimpac%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Grandview%20Christian%20Home</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bernick's%20Full-Line%20Vending%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MINNESOTA%20ONCOLOGY%20HEMATOLOGY%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vickerman%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rihm%20Motor%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Benilde-St.%20Margaret's%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Pope</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Oxygen%20Service%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NORTHWOOD%20CHILDREN'S%20HOME%20SOCIETY%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Emanuelson-Podas%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Northfield</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Geritom%20Med%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PETERSON%20COMPANIES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Servion%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AG%20Partners%20Coop</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LASX%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nelson%20Leasing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ritalka%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Avon%20Plastics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dalsin%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Reviva%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Hermantown</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/E%20%26%20H%20Enterprises%20of%20Alexandria%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Loaves%20%26%20Fishes%20Too</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gamer%20Packaging%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AVR%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Seasonal%20Specialties%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHILD%20CARE%20RESOURCE%20AND%20REFERRAL%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Christ's%20Household%20Of%20Faith%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Collective%20Measures%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southdale%20Pediatric%20Associates%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Paul%20A.%20Schmitt%20Music%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Neighborhood%20Recycling%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mate%20Precision%20Technologies%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mahube-Otwa%20Community%20Action%20Partnership%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PORTAGE%20ENERGY%20PARTNERS%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Global%20Specialty%20Contractors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Smart%20Data%20Solutions%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anderson%20Brothers%20Construction%20Company%20of%20Brainerd%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WASHBURN%20CENTER%20FOR%20CHILDREN</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Toltz%2C%20King%2C%20Duvall%2C%20Anderson%20And%20Associates%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Frerichs%20Construction%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mikros%20Engineering%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ralco%20Nutrition%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bay%20West%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Morcon%20Construction%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ace%20Supply%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Unified%20Screening%20%26%20Crushing%20-%20Mn%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Alexandria%2C%20City%20Of%20(inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Three%20Rivers%20Community%20Action%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LS%26D%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Community%20Co-Op%20Oil%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tempco%20Manufacturing%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plainview-Elgin-Millville%20School%20District%202899</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Medica%20Holding%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Larson%20Engineering%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Key%20Enterprises%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dan%20Larson%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Suburban%20Manufacturing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SEACHANGE%20PRINTING%20AND%20MARKETING%20SERVICES%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MINNEAPOLIS%20JEWISH%20FEDERATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/A.M.P.%20Manufacturing%20And%20Supply%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Robbinsdale</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Thermo%20King%20Sales%20%26%20Service%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Royal%20Tire%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Melrose%20Independent%20School%20District%20740</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Accanto%20Health%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CSM%20MPLS%20West%2C%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lester%20Building%20Systems%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GUILD</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Johnson%2FAnderson%20%26%20Associates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnetronix%20Medical%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Summit%20Landmark%20Orthopedics%20Ltd</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TMI%20Coatings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Norman</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Delta%20Industrial%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Taj%20Technologies%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Pipestone</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/REDWOOD%20AREA%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Xigent%20Solutions%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jordan%20Transformer%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Schuler%20Shoes%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tolomatic%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/3520%20Xenwood%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lang-Nelson%20Associates%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Brainerd</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Specialties%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Edco%20Products%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FRAN'S%20SUPERMARKETS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DC%20Group%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Everidge%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NORTH%20STAR%20CONSULTANTS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Warrior%20Mfg.%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Advantage%20Transportation%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Richfield%20Dual%20Language%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ebenezer%20Management%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hibbing%20Public%20Utilities%20Commission</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SENIOR%20HOUSING%20PARTNERS%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vigen%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nerdery%20Interactive%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Schadegg%20Mechanical%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Glencoe-Silver%20Lake%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Berwald%20Roofing%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Donlar%20Construction%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Howard%20Lake-Waverly-Winsted%20ISD%20%232687</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hyder%20Investments%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dunham%20Associates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nilan%20Johnson%20Lewis%20PA</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20Cloud%20Industrial%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Summit%20Orthopedics%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20Cloud%20Orthopedic%20Associates%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quest%20Engineering%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LAKE%20CITY%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lindsay%20Sash%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Archdiocese%20of%20Saint%20Paul%20and%20Minneapolis</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vanco%20Payment%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Clim-A-Tech%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SRF%20Consulting%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Meridian%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ACCORD</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Baxter</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Scalzo%20Hospitality%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rosenbauer%20Minnesota%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Revol%20Greens%20MN%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Murphy%20Logistics%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pioneer%20Plastics%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Oil-Air%20Products%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Brighton%20Hospice%20Minnesota%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lakes%20Gas%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jackson%20County%20Central%20Schools%20Independent%20School%20District%202895</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TEGRETE%20CORPORATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crest%20View%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Horizontal%20Integration%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20Look%20Contracting%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Mold%20%26%20Engineering%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/EBENEZER%20RIDGES</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/VSI%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Johanneson's%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crown%20Bankshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Oliver%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Luverne%20Public%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bob%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quality%20Metals%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CCRI%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Navy%20Island%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TC%2FAmerican%20Crane%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHARLES%20K.%20BLANDIN%20FOUNDATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MINNETONKA%20MOCCASIN%20COMPANY%2CINC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Lac%20Qui%20Parle</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ronco%20Engineering%20Sales%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stahl%20Construction</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Larkin%2C%20Hoffman%2C%20Daly%20%26%20Lindgren%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Morris%20Area%20Independent%20School%20District%20769</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ebert%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GOODMANSON%20CONSTRUCTION%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minneapolis%20Rag%20Stock%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Saint%20Elizabeth's%20Hospital%20of%20Wabasha%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Rock</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Evolving%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Streamworks%20L.%20L.%20C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MidWest%20Bancorporation%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/THE%20DULUTH%20REGIONAL%20CARE%20CENTER%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Commercial%20Flooring%20Services%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sibley%20Medical%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/L.%20S.%20Black%20Constructors%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SIT%20Investment%20Associates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bituminous%20Roadways%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plunkett's%20Pest%20Control%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pharmaceutical%20Specialties%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hernesman%20And%20Sons%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Corrugated%20Box%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Coughlan%20Companies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Etoc%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DEER%20RIVER%20PUBLIC%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Bemidji</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gresser%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Detroit%20Lakes</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Boker's%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AbleNet%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mid-Continent%20Engineering%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sabis%20Educational%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Impressions%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pillager%20Public%20School%20Dist%20116</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Food%20Group%20Minnesota%20Inc..</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Coherent%20Solutions%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Interlachen%20Country%20Club</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dairy%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northfield%20Telecommunications%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Heartland%20Paving%20Partners%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Retrofit%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pierz%20Independent%20School%20District%20484</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Structures%20Hardscapes%20Specialists%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20%23316</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Madison%20Healthcare%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Animal%20Humane%20Society</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/phData%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Community%20School%20of%20Excellence</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wipaire%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/APG%20Cash%20Drawer%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crest%20Electronics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anoka%20County%20Community%20Action%20Program%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/First%20Alliance%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Aagard%20Group%2C%20L.L.C</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MID-MINNESOTA%20LEGAL%20ASSISTANCE</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ROSEAU%20ELECTRIC%20COOPERATIVE%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Society%20Of%20Corporate%20Compliance%20And%20Ethics%20%26%20Health%20Care%20Compliance%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Met-con%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vector%20Windows%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Solution%20Design%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quicksilver%20Express%20Courier%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Electro%20Watchman%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/First%20National%20Financial%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cuningham%20Group%20Architecture%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lyndale%20Terminal%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NORTH%20HOMES%20INC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Brutger%20Equities%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WNB%20Financial%2C%20National%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southview%20Acres%20Health%20Care%20Center%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Pines%20Mental%20Health%20Center%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bayer%20Built%20Woodworks%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%202155</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Analysts%20International%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Polywater%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/West%20Central%20Steel%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bauer%20Design%20Build%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Padilla%20Speer%20Beardsley%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Land%20Trust</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/JBT596165%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Landwehr%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lac%20Qui%20Parle%20Valley%20ISD%202853</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Constellation%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHANNEL%20ONE%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Beaudry%20Oil%20%26%20Service%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Erik's%20Bike%20Shop%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AxisNorth%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Grace%20Management%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Grant</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pipestone%20Area%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St%20James%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lionsgate%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Reell%20Precision%20Manufacturing%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/S.M.%20Hentges%20%26%20Sons%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Semcac</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vanguard%20Graphics%20International%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/J%20%26%20E%20Manufacturing%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/3M%20Open%20Fund</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Forest%20Lake</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Super%20Set%20Flooring%20%26%20Tile%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/QCL%20HoldCo%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Environmental%20Plant%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/QCL%20HoldCo%2C%20Inc.</loc>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kahler%20Automation%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20North%20Mankato</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Sartell</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/World%20Food%20Processing%2C%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ROSEAU%20SCHOOL%20DISTRICT%20682</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Austin%20Mutual%20Insurance%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mapleriver%20School%20District%20%232135</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Viking%20Drill%20%26%20Tool%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Minikahda%20Club</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Goodhue%20County%20Education%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Waite%20Park</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TruStar%20Federal%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Corcoran</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Timberland%20Transportation%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gregory's%20Foods%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Building%20Restoration%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GRE%20Herc%20Services%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Advanced%20Molding%20Technologies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/John%20B.%20Goodman%20Limited%20Partnership</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Higher%20Ground%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LONG%20PRAIRIE-GREY%20EAGLE%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ST.%20CROIX%20PREPARATORY%20ACADEMY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tjernlund%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Schwegman%20Lundberg%20%26%20Woessner%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ace%20Electrical%20Contractors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Prairie%20Ridge%20Hospital%20and%20Health%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hmong%20American%20Partnership</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Scott%20Equipment%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Osborne%20Properties%20Limited%20Partnership</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sterling%20Bancorporation%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/W.%20Gohman%20Construction%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LYDIAN%20ENERGY%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Icario%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Twin%20Cities%20International%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Samaritan%20Bethany%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anderson%20%26%20Dahlen%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Advanced%20Duplication%20Services%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quantronic%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/THE%20LINDGREN%20GROUP%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Whitebirch%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pawn%20America%20Minnesota%2C%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sibley%20East%20Public%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/U%20%26%20I%20Entertainment%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/D%20%26%20M%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Handi%20Medical%20Supply%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ordway%20Center%20For%20The%20Performing%20Arts</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Village%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gravie%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mid%20Minnesota%20Federal%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lano%20Equipment%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rochester%20Catholic%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Augustana%20Mount%20Olivet%20Hospice%20Care%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hugo%20City%20Hall</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kensington%20Bancorp.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ericksen%2C%20Roed%20and%20Associates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Episcopal%20Church%20Home%20of%20Minnesota%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mielke%20Oil%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Citi%20-%20Cargo%20%26%20Storage%20Co.%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Danny's%20Construction%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Malton%20Electric%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Board%20Of%20Pensions%20of%20the%20Evangelical%20Lutheran%20Church%20in%20America</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SAINT%20PAUL%20RIVERCENTRE%20CONVENTION%20%26%20VISITORS%20AUTHORITY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HOMEWARD%20BOUND%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MUSTAD%20CONNECTICUT%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midwest%20Rubber%20Service%20%26%20Supply%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Doherty%20Consulting%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Meadowland%20Farmers%20Coop.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rice%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plasti%20Dip%20International%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BORDER%20FOODS%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Wire%20%26%20Cable%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Indian%20Health%20Board%20of%20Minneapolis%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Simplex%20Supplies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Capstan%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20John's%20Lutheran%20Home%20of%20Albert%20Lea</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Building%20Contractors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WILCOX%20BANCSHARES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Real%20Estate%20Equities%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hinckley%20Finlayson%20School%20District%202165</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Housing%20and%20Redevelopment%20Authority</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northwest%20Area%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Heartland%20Realty%20Investors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lawrence%20Transportation%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ALLUMA%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vyriad%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Taylor%20Truck%20Line%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lueken's%20Food%20Stores%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cedar%20Valley%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Murray</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/N%20C%20Holdings</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Progressive%20Rail%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/D'amico%20%26%20Partners%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Food%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bro-Tex%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BE%20THE%20MATCH%20BIOTHERAPIES%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Christensen%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dell-Comm%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LAKELAND%20MENTAL%20HEALTH%20CENTER%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St%20Cloud%20Financial%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Richfield-Bloomington%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Metal%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lac%20Qui%20Parle%20Cooperative%20Oil%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Native%20American%20Community%20Clinic</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Precision%20Associates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Alltech%20Engineering%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hoglund%20Bus%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stuart%20Co</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RSP%20Architects%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fey%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Yale%20Mechanical%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Village%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Commercial%20Railway%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Mathiowetz%20Construction%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Lincoln</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Big%20Stone</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NORTHLAND%20COUNSELING%20CENTER%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Washington%20County%20Community%20Development%20Agency</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Field%20Nation%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Warroad%20Public%20Schools%20Independent%20School%20District%20690</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lakes%20International%20Language%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Delegard%20Tool%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Blue%20Earth%20Valley%20Communications%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AITKIN%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Green%20Mill%20Restaurants%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Creative%20Laboratories%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Winthrop%20%26%20Weinstine%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CANNON%20FALLS%20AREA%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Community%20of%20Peace%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dover-eyota%20Public%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Data%20Panel%20Acquisition%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quality%20Ingredients%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Madelia%20Community%20Hospital%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ideal%20Printers%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/JONES-HARRISON%20RESIDENCE</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Heartland%20Corn%20Products</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sunburst%20Chemicals%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Blue%20Earth%20Area%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fedtech%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Engelsma%20Construction%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rochester%20Motor%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Belle%20Plaine</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Edwards%20Oil%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Legend%20Mechanical%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SMA%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Visions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nuway-K%26H%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/VIRNIG%20MANUFACTURING%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Fairmont</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tastefully%20Simple%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Citizens%20National%20Bank%20Park%20Rapids%20(Inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Summit%20Academy%20OIC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Brown%20Tank%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Electramatic%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Cambridge</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Johnsrud%20Enterprises%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Koda%20Energy%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/G.%20M.%20Northrup%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Doherty%20Employment%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minneapolis%20Glass%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Control%20Assemblies%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hutchinson%20Senior%20Care%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Minnesota%20Wisconsin%20Area%20Retail%20Food%2C%20Health%20%26%20Welfare%20Fund</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Walker%20Hackensack%20Akeley%20School%20District%20113</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Waconia</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Minnesota%20Nurses'%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Superior%20Third%20Party%20Logistics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Otsego</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Mendota%20Heights</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/T%20M%20S%20Johnson%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20East%20Grand%20Forks</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kittson%20Memorial%20Hospital%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plainview%20Bankshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Schneiderman%20Furniture%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20AG%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Class%20C%20Components%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MOLINE%20MACHINERY%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Productivity%20Quality%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jefferson%20Partners%20L.P.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cybertrol%20Engineering%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Utilimarc%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CROSBY-IRONTON%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Brown%20County%20Rural%20Electrical%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20St.%20Anthony</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/International%20Falls%20Independent%20School%20District%20%23%20361</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20Therese%20of%20Woodbury%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ARROWHEAD%20ELECTRIC%20COOPERATIVE%2CINC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rogers%2C%20Freels%20%26%20Associates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ramsey%20Excavating%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FMS%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Process%20Measurement%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/World%20Data%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Envision%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MHC%20Software%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RUSH%20CITY%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Indian%20Land%20Tenure%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Reese%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Libra%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Star%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St.%20Therese%20At%20Oxbow%20Lake%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Razr%20Marketing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ACGC%20NORTH%20ELEM.%20SCHOOL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RENVILLE%20SIBLEY%20COOP%20PoWeR%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St%20Cloud%20Metro%20Transit%20Commission</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SHARING%20AND%20CARING%20HANDS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lefebvre%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Touchstone%20Mental%20Health</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/International%20Feed%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/OSP%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Greater%20Minnesota%20Family%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HOLDINGFORD%20INDEPENDENT%20SCHOOL%20DISTRICT%20738</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Waubun%20Independent%20School%20District%20435</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NACS%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Agate%20Housing%20and%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/U.M.C.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minn-Kota%20AG%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20No.%202365</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WRZ%20BANKSHARES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20National%20Sports%20Center%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Doran%20Construction%20Company%2C%20Llc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pioneer%20Home%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DULUTH%20PUBLIC%20SCHOOLS%20ACADEMY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PAYNESVILLE%20AREA%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/A%20Subsidiary%20of%20Mars%20Supply</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Co-Op%20Credit%20Union%20of%20Montevideo</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hendricks%20Community%20Hospital%20Association%20and%20Retirement%20Home</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Associated%20Eye%20Care%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Leum%20Engineering%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FIRST%20BANCSHARES%2C%20INC.%20OF%20COLD%20SPRING</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plastics%20International%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Aero%20-%20Space%20-%20Computer%20Supplies%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hough%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Minnesota%20Senior%20Housing%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Productive%20Alternatives%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GUARDIAN%20ANGELS%20HEALTH%20SERVICES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/EAST%20CENTRAL%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Hardware%20Distribution%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20777</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Hospital%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cherokee%20Manufacturing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PRAIRIE%20SEEDS%20Charter%20ACADEMY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Atlas%20Staffing%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Red%20River%20Valley%20Cooperative%20Power%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ARROW%20FINISHING%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Caresfield%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BEST%20ACADEMY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Garda%20Capital%20Partners%20LP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Redwood%20Electric%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Transport%20Designs%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tempworks%20Software%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/JP%20Ecommerce%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mahnomen%20School%20District%20432</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Girl%20Scouts%20Of%20Minnesota%20And%20Wisconsin%20River%20Valleys%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FM%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Medina</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wayzata%20Investment%20Partners%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dahmes%20Stainless%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Iracore%20International%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Affinitech%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lakeview%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Widseth%20Smith%20Nolting%20%26%20Associates%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Maccray%20Ind%20School%20Dist%202180</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Seven%20Hills%20Classical%20ACA</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Powder-Solutions%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Traverse</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Esko%20School%20District%2099</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SOMIC%20PACKAGING%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Moss%20%26%20Barnett%2C%20a%20Professional%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Indian%20Community%20Development%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/One10%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Universal%20Transportation%20Services%2C%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Le%20Sueur-Henderson%20Public%20School%20District%20%232397</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/UNIV.%20OF%20MINNESOTA</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Central%20Equity%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Product%20Development%20Associates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Holdingford%20Public%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PARNASSUS%20PREPARATORY%20SCHOOL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cook%20Area%20Health%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BerganKDV%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHEROKEE%20BANCSHARES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Dayton</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rainy%20Lake%20Oil%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BLUE%20EARTH%20ISD%202860</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Barnesville%20Public%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northland%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Prespyterian%20Home%20Maranatha</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MVC%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Premise%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pillsbury%20United%20Communities</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pelican%20Rapids%20Independent%20School%20District%20548</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Star%20Electric%20Cooperative%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Manufacturing%20Solutions%20Of%20MN%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gulbranson%20Excavating%20Co</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Consulting%20Radiologists%2C%20Ltd.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Morrissey%20Hospitality%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/75F%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BAKKEN%20SECURITIES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bassford%20Remele%2C%20A%20Professional%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHS%20Cooperatives</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Western%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Saint%20Paul%20Area%20Electrical%20Joint%20Apprenticeship%20And%20Training%20Fund</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Properties%20Investment%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mead%20Metals%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Waters%20Senior%20Living%20Management%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hinckley-Finlayson%20Public%20Schools%20Independent%20School%20District%20No.2165</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northrock%20Partners%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HAWLEY%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Big%20Gain%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Shelter%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Warren%20Community%20Hospital%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20821</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Community%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Triton%20Independent%20School%20District%20%232125</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Brenk%20Brothers%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Morris%20Packaging%20Minnesota%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Blooming%20Prairie%20School%20ISD%20No.%20756</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Clow%20Stamping%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Cook%20Hospital</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TWIN%20CITIES%20INTERNATIONAL%20ELEMEMTARY%20SCHOOL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ST.%20CHARLES%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TT%20Capital%20Partners%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minneapolis%20Oxygen%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nura%2C%20PLLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hoffman%2Fweber%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Invest%20Cast%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Malco%20Tools%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hope%20Community%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rohn%20Industries%2C%20Inc.-St.%20Paul</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RED%20LAKE%20ELECTRIC%20COOPERATIVE%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Orono</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Performance%20Office%20Papers%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Regalo%20International%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MCG%20Energy%20Solutions%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Reliance%20Bancorporation%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Venture%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PINE%20RIVER-BACKUS%20SCHOOL%20DIST%202174</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Estates%20At%20Roseville%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Viking%20Client%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Interfaith%20Outreach%20and%20Community%20Partners</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/YWCA%20of%20Minneapolis</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Sauk%20Rapids</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mactech%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Comunidades%20Latinas%20Unidas%20En%20Servicio%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Highland%20Management%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RS%20Eden</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20Millennium%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Warner%20Manufacturing%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Farmers%20%26%20Merchants%20State%20Bank%20(inc)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/EMA%20GROUP%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LAKE%20CRYSTAL-WELLCOME%20MEMORIAL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hardrives%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/P.K.M.%20ELECTRIC%20CO-OPERATIVE%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SCOTT-CARVER-DAKOTA%20CAP%20AGENCY%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHATFIELD%20PUBLIC%20SCHOOL%20DISTRICT%20227</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LTX%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/O'Shaughnessy%20Holding%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pine%20River%20Capital%20Management%20L.P.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Haven%20Homes%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/County%20of%20Mahnomen</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Doran%20Companies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midwest%20Interventional%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Horizon%20Equipment%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hired</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bepex%20International%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/COCHRAN%20RECOVERY%20SERVICES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20881</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BCI%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Messerli%20%26%20Kramer%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ROYALTON%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hedberg%20Aggregates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LSP-Cottage%20Grove%2C%20L.P.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tracy%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FRAZEE-VERGAS%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/Chartwell%20Financial%20Advisory%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Optimity%20Advisors%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/Chartwell%20Financial%20Advisory%2C%20Inc.</loc>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CUSTOM%20PRODUCTS%20OF%20LITCHFIELD%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mille%20Lacs%20Bancorporation%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Spsi%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Saint%20Peter</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/S%20M%20D%20C%20St%20Mary's%20Duluth%20Clinic%20Health%20System%20Hospice%20%26%20Palliative%20Care</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bagley%20Independent%20School%20District%20162</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Scott%20County%20Community%20Development%20Agency</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Chisholm</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CENTRICITY%20CREDIT%20UNION%20FOUNDATION%20INC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gray%2C%20Plant%2C%20Mooty%2C%20Mooty%20%26%20Bennett%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Robert%20A%20Williams%20Enterprises</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DecksDirect%3B%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MICHEL%20SALES%20COMPANY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Edney%20Distributing%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Con-tech%20Manufacturing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Cooperative%20Light%20%26%20Power%20Association%20of%20Lake%20County</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Perham</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Open%20Arms%20Of%20Minnesota</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kato%20Cable%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Traverse%20Electric%20Cooperative%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Onamia%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southwest%20Minnesota%20Housing%20Partnership</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/EDEN%20VALLEY-WATKINS%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/APPLETON%20AREA%20HEALTH</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quality%20Circuits%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Liberty%20Classics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fortune%20Transportation%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/C%20%26%20B%20Material%20Handling%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Veap%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MAMAC%20SYSTEMS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Dewatering%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/IdeaCom%20Mid-America%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Catheter%20and%20Medical%20Design%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Park%20View%20Care%20Center%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wand%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CATTAIL%20BANCSHARES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20St%20Michael</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Mounds%20View</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/True%20North%20Goodwill%20Northern%20Minnesota%20and%20Northwestern%20Wisconsin</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20South%20Central%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Menahga%20Ind%20School%20Dist%20821</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Louis%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Monteris%20Medical%20US%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lake%20Park%20-Audubon%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lake%20Superior%20Community%20Health%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southern%20Minnesota%20Regional%20Legal%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minneapolis%20Heart%20Institute%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHOSEN%20VALLEY%20CARE%20CENTER%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ST.%20CLAIR%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Life-Science%20Innovations%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Channel%20Partners%20Capital%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Akkerman%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Athlos%20Leadership%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Carlson%20%26%20Stewart%20Refrigeration%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hydra-Flex%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Araz%20Group%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/THRIVENT%20FINANCIAL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Boiler%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/K.T.I.%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Country%20Food%20Bank%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PRESBYTERIAN%20HOMES%20MILL%20POND%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Flywheel%20Exchange%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Osakis%20Independent%20School%20District%20%23213</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Normandale%20Community%20College</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lakes%20Community%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Goodhue%20County%20Cooperative%20Electric%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20Wave%20Design%20and%20Verification%2C%20LLC%20dba%20New%20Wave%20Design</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Production%20Engineering%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Fibersmith%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sherman%20Associates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Braham%20Independent%20School%20District%20%23314</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Interim%20HealthCare%20of%20the%20Twin%20Cities%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Minority%20Business%20Forms%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Radiation%20Protection%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Matrix%20Communications%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ELECTRIC%20MOTOR%20SUPPLY%20COMPANY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MEDFORD%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Carley%20Foundry%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/REVERENCE%20FOR%20LIFE%20AND%20CONCERN%20FOR%20PEOPLE%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Security%20State%20Bancshares%20of%20Bemidji%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PETERSON'S%20NORTH%20BRANCH%20MILL%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Miller%20Felpax%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Goodson%20Manufacturing%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Zelle%20LLP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20Richland-Hartland%20Isd%202168</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bushmills%20Ethanol%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rainbow%20Tree%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/East%20Side%20Oil%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crossroads%20Trailer%20Sales%20%26%20Service%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bois%20Forte%20Multi-Service%20Center%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20States%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LADC%20COMPANIES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Waterville-Elysian-Morristown%20School%20District%202143</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vision%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Horizon%20Roofing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHISHOLM%20PUBLIC%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Numerically%20Automated%20Cutting%20Systems%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cooperative%20Light%20And%20Power%20Association%20Of%20Lake%20County</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ASI%20DataMyte%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MINNESOTA%20EQUIPMENT%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Little%20Canada</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/West%20Central%20Minnesota%20Communities%20Action%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Jewish%20Community%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Caledonia%20Independent%20School%20District%20299</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cooperative%20Plating%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Star%20Equipment%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/THE%20MINNESOTA%20OPERA</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KIMBALL%20AREA%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/St%20Anthony%20Nursing%20Home%20Limited%20Partnership</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rural%20Health%20Resource%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Seven%20Hills%20Classical%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Shipper's%20Supply%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Greater%20Minneapolis%20Convention%20%26%20Visitors%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ShoreMaster%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Border%20States%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Lake%20Elmo</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/West%20Central%20Telephone%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Assumption%20Home%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pequot%20Tool%20%26%20Mfg.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20North%20Saint%20Paul</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Viking%20Financial%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Aquarius%20Water%20Conditioning%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Victoria</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sourcewell</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Abdallah%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Thief%20River%20Falls</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KENYON-WANAMINGO%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/In%20Control%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Delano</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Coen%20%26%20Partners%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northland%20Concrete%20%26%20Masonry%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Owens%20Technology%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Family%20Pathways</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cook%20County%20North%20Shore%20Hospital</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ABILITY%20BUILDING%20CENTER%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Link</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mesabi%20Metallics%20Company%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Warning%20Lites%20Of%20Minnesota%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/New%20York%20Mills%20Independent%20School%20District%20%23553</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dayspring%20Productions%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Supply%20Chain%20Services%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Big%20Brothers%20Big%20Sisters%20Of%20The%20Greater%20Twin%20Cities</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PROFESSIONAL%20SERVICE%20BUREAU%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Yellow%20Medicine%20East%20Independent%20School%20District%202190</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Legacy%20Christian%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Warren-Alvarado-Oslo%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Home%20Town%20Federal%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southside%20Community%20Health%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Metro%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Wayzata</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ST.%20PAUL%20CITY%20SCHOOL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wildamere%20Capital%20Management%2C%20L.%20L.%20C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Contract%20Hardware%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Atlas%20Foundation%20Co.%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sonus%20Interiors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GOLF%20STIX%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Genz-Ryan%20Plumbing%20And%20Heating%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Corner%20Medical%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stix%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WINNESOTA%20Multi-Temp%20Delivery%20and%20Storage%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Two%20Harbors%20Machine%20Shop%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/F%20S%20S%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southwest%20Initiative%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Avinity%20Senior%20Living</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FNB%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/True%20Friends</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/P%20H%20M%20Eaglecrest%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Autoscope%20Technologies%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RED%20LAKE%20NATION%20COLLEGE</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HIGHLAND%20MANOR%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dart%20X%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northwestern%20College%20Radio%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DULUTH%20TRANSIT%20AUTHORITY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wabasha-Kellogg%20Public%20School%20District%20%23811</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Goetsch%2C%20W%20W%20Associates%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/South%20Central%20Human%20Relations%20Center%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HOSPITAL%20PATHOLOGY%20ASSOCIATES%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NIM%20III%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Falls%20Fabricating%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midwest%20Steel%20Supply%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Multifeeder%20Technology%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SharePoint%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Control%20Concepts%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Firstat%20Nursing%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Simcote%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mulcahy%20Nickolaus%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Duluth%20Area%20Family%20Y.M.C.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Counties%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Guardian%20Angels%20Elim%20Home%20Care%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Valley%20Craft%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Delano%20Municipal%20Utilities</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Custom%20Drywall%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LTL%20LED%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rock%20River%20Industries%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anoka%20Hennepin%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/C%20%26%20H%20Technology%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Russell%20Tyler%20Ruthton%20School%20District%202902</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Local%20Government%20Information%20Systems%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ENDRES%20PROCESSING%2C%20LTD</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Park%20Bank%20Corporation%20of%20Duluth</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ADA-BORUP-WEST%20INDEPENDENT%20SCHOOL%20DISTRICT%202910</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Morris%20Co-op%20Assn.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bankers%20Equipment%20Service%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Prescription%20Landscape%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WEST%20CENTRAL%20AREA%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LIBERTY%20FINANCIAL%20SERVICES%20OF%20ST.%20CLOUD%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Auto%20Approve%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Valley%20Memorial%20Hospital%20Foundation%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Surface%20Preparation%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southern%20Lighting%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Petroleum%20Service%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FLEXSEALS%2C%20INC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20195</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Doran%20Management%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Consolidated%20Trading%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Blackduck%20Independent%20School%20District%2032</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lazard%20Middle%20Market%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dane%20Technologies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Prairie%20Five%20Community%20Action%20Council%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hearth%20Connection</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LAKES%20%26%20PRAIRIES%20COMMUNITY%20ACTION%20PARTNERSHIP%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ELECTRICAL%20POWER%20AND%20SAFETY%20COMPANY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Transport%20Express%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Master%20Mechanical%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%202154</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Light%20Color%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mechatronic%20Solutions%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Waseca</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/YINGHUA%20ACADEMY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DIESEL%20DOGS%20FUEL%20SERVICE%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Shore%20Federal%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ISD%20763%20MEDFORD%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Independent%20School%20District%20775</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plato%20Holdings%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Alliant%20Engineering%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/OlympiaTech%20Electrical%20Contractors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Thomas%20Engineering%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wellington%20Management%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Itasca%20Hospital%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Greater%20Community%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GFW%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Center%20For%20Alcohol%20and%20Drug%20Treatment</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PROACT%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HealthPartners</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Boarman%20Kroos%20Vogel%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Highland%20Properties%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MOUNT%20OLIVET%20HOME</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pulse%20Outreach</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/APX%20CONSTRUCTION%20GROUP%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Clyde%20Machines%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AWR%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kottke%20Trucking%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Financial%20Services%20of%20Winger%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Urology%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/European%20Roasterie%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CITIZENS%20BANCSHARES%20OF%20HUTCHINSON%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SPRINGFIELD%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Traut%20Companies</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Runestone%20Telephone%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/R.%20E.%20PURVIS%20%26%20ASSOCIATES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MOUNTAIN%20IRON-BUHL%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Gillespie%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Interstate%20Motor%20Trucks%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Children's%20Theatre%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jewish%20Family%20And%20Children's%20Service%20Of%20Minneapolis</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Commerce%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Little%20Falls</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/UNITED%20HEALTH</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Med-Diet%20Laboratories%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MERRICK%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wilson-Mcshane%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Business%20Development%20Sales%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/THE%20PHOENIX%20RESIDENCE%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Dynamic%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Kasson</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Be%20The%20Match%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RUM%20RIVER%20BANCORPORATION%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Janesville%20Waldorf%20Pemberton%20Independent%20School%20District%202835</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Capitol%20Beverage%20Sales%20Limited%20Partnership</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/B.F.%20Nelson%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dawson-Boyd%20Public%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Architecture%20Technology%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Groebner%20%26%20Associates%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sunset%20Dental%20Technologies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fillmore%20Central%20ISD%202198</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ROCHESTER%20MATH%20%26%20SCIENCE%20ACADEMY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MARKETING%20ARCHITECTS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Excel%20Engineering%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Repnet%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KFI%20Engineers%2C%20PC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NOVA%20CLASSICAL%20ACADEMY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TCF%20FINANCIAL%20CORP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Noble%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SUSTAINABLE%20RESOURCES%20CENTER%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mathias%20Die%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kuepers%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PFC%20Equipment%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/On%20Site%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Enviromatic%20Corporation%20Of%20America%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mid-America%20Business%20Systems%20And%20Equipment%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Marshall%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TRI-COUNTY%20COMMUNITY%20ACTION%20PARTNERSHIP%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bridging%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lakeview%20Independent%20School%20District%202167</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northwoods%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MACPHAIL%20CENTER%20FOR%20MUSIC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Olmsted%20Holding%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/United%20Language%20Group%20Operations%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Belgrade-Brooten-Elrosa%20Independent%20Schools%20District%20%232364</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nparallel%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/K%20A%20S%20Investment%20Co%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Twin%20City%20Outdoor%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rushford-Peterson%20ISD%20239</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BH%20Electronics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Farm-Rite%20Equipment%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Madelia%20Independent%20School%20District%20837</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rochester%20Minnesota%20Convention%20And%20Visitors%20Bureau</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Auto%20Butler%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Universal%20Financial%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DALEY%20ELECTRIC%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CHIPPEWA%20PACKAGING%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Goldner%20Hawn%20Johnson%20%26%20Morrison%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Mound</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PEOPLE%20SERVING%20PEOPLE%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Flexible%20Circuit%20Technologies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Two%20Men%20And%20A%20Truck</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hayfield%20Independent%20School%20District%20203</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Grand%20Village</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Windom</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wayzata%20Country%20Club</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Terwisscha%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lindsay%20Windows%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Centerpoint%20Marketing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LYON-LINCOLN%20ELECTRIC%20COOPERATIVE%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Cloquet</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Project%20Success</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DRIP%20GLOBAL%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Big%20Lake</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CONDUCTIVE%20CONTAINERS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fosston%20Independent%20School%20District%20%23601</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Vetter%20Stone%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Adam's%20Pest%20Control%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Piesco%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Murray%20County%20Central%20Disrict%202169</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Elire%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Prospect%20Foundry%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/When%20I%20Work%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Goodhue%20Independent%20School%20District%20253</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Neighborhood%20House</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Railway%20Equipment%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Valve%20And%20Fitting%20Company%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mill%20City%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Paape%20Distributing%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cologne%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Tri-County%20Action%20Program%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rural%20Minnesota%20Cep%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CATHOLIC%20SCHOOLS%20CENTER%20OF%20EXCELLENCE</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HARRY%20MEYERING%20CENTER%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GeoDigm%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dem-Con%20Companies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Barnum%20Independent%20School%20District%20%2391</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Riverland%20Bancorporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Encompass%20Pipeline%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northern%20Computer%20Technologies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Conservation%20Corps</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/COOK%20COUNTY%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ess%20Brothers%20And%20Sons%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/South-town%20Refrigeration</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Moose%20Lake%20Community%20Schools%20ISD%20%2397</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hayden-murphy%20Equipment%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Mahtomedi</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Energy%20Economics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Silver%20Tree%20Plumbing%20%26%20Heating%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Floor%20Source%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/High%20Plains%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Styer%20Transportation%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Federated%20Telephone%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jonaco%20Machine%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KODA%20LIVING%20COMMUNITY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hiawatha%20Valley%20Mental%20Health%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Aurora%20Pharmaceutical%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AllOver%20Media%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sabre%20Plumbing%2C%20Heating%20And%20Air%20Conditioning%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hartland%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Definitive%20Technology%20Solutions%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AAA%20MOVERS%20INC.%20OF%20MINNEAPOLIS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FAMILY%20SERVICE%20ROCHESTER%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pier%20Foundry%20%26%20Pattern%20Shop%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Schott%20Distributing%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/STATE%20SUPPLY%20CO.%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Luther%20Haven</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Standard%20Heating%20%26%20Air%20Conditioning%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/All%20American%20Foods%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Direct%20Connect%20Transport%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sentera%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jnr%20Adjustment%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Intact%20Services%20USA%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/J%20%26%20R%20Schugel%20Logistics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Munson%20Lakes%20Nutrition%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TUBMAN</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midwest%20Special%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Citizens%20State%20Bank%20of%20Roseau</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gold%20Country%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Ham%20Lake</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Second%20Street%20Steel%20Supply%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anderson%20Cargo%20Services%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Novation%20Credit%20Union%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20North%20Branch</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Integrated%20Recycling%20Technologies%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Lake%20City</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Corporate%20Direct%20Apparel%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bold%20Orange%20Company%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Duluth%20Health%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Martin%20County%20West%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Belgarde%20Enterprises</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ogilvie%20Ind%20School%20Dist%20333</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Service%20Lighting%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Endura%20Financial%20Federal%20Credit%20Union</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Order%20of%20St.%20Benedict</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KIVI%20BROS.%20TRUCKING%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Diversified%20Plastics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stone%20Arch%20Commodities%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MIDWEST%20FAMILY%20MUTUAL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bergin%20Fruit%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Arc%20Minnesota%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Range%20Mental%20Health%20Center%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Esco%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/IPP%20Buyer%20Holdings%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FAMILIA</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Clinic%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Clearbrook-Gonvick%20Independent%20School%20District%202311</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/D'Amico%20Holding%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/DURAG%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Smackin%20Snacks%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wadena%20Bankshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Metropolitan%20Community%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SIMPSON%20HOUSING%20SERVICES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Range%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Table%20Trac%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Martin%20Calibration%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cyber%20Advisors%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Daily%20Printing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Arnold's%20Of%20St.%20Martin%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FREEBORN%20COUNTY%20COOPERATIVE%20OIL%20COMPANY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Jones%20Metal%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Partnership%20Academy%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Great%20River%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fulton%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Our%20Lady%20of%20Peace</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Union%20Bank%20And%20Trust%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GMI%20OpCo%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/National%20Conductor%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Renville%20County%20West%20Independent%20School%20District%20No.%202890</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Incisive%20Surgical%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ancom%20Communications%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KSP%20FULFILLMENT%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wilkin%20County%20Ind%20School%20District%20846</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FLOE%20INTERNATIONAL%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kingsland%20Public%20Schools%20Independent%20School%20District%20%232137</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bonfe's%20Plumbing%20Heating%20%26%20Air%20Service%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/LAKES%20AND%20PINES%20COMMUNITY%20ACTION%20COUNCIL%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CENTER%20NATIONAL%20BANK</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/Structural%20Wood%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/V-Tek%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/Structural%20Wood%20Corporation</loc>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MED%20CITY%20ELECTRIC%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Chandler%20Feed%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Inter-faith%20Care%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ely%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Surly%20Brewing%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Schwartz%20Bros%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Flextech%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/North%20Branch%20City%20Hall</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Agriliance%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Praying%20Pelican%20Missions</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/High%20Bar%20Brands%20Operating%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Best%20%26%20Flanagan%20LLP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Cleveland%20Public%20School%20District%20391</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SUITE%20LIVING%20SENIOR%20CARE%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Frattallone's%20Hardware%20Stores%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ace%20Telephone%20Association</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TRADEMARK%20TRANSPORTATION%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AGILIS%20CO.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Northland%20Community%20Independent%20School%20District%20118</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Valley%20Transportation%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HOME%20AND%20COMMUNITY%20OPTIONS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CARHOP%20AUTO%20SALES%20AND%20FINANCE</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RADEMACHER%20COMPANIES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/A-L%20OUTDOORS%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Fabyanske%2C%20Westra%2C%20Hart%20%26%20Thomson%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Archetype%20Signmakers%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/International%20Chemtex%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CAPITOL%20REGION%20WATERSHED</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Annandale%20Care%20Center</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plato%20Woodwork%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Superior%20Freight%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kerkhoven%20Murdock%20Sunburg%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Glenwood%20Village%20Care%20Center%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Timberwolves%20Basketball%20Limited%20Partnership</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Central%20Power%20Distributors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Modern%20Molding%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PL%20Enterprises%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/AXXYS%20Construction%20Group%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Precision%20Gasket%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/BLUESTONE%20PHYSICIAN%20SERVICES%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Discover%20Plastics%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hiawatha%20Homes%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NorthPoint%20Health%20%26%20Wellness%20Center%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Eastside%20Food%20Cooperative</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kamp%20Automation%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SOUTHWEST%20CHRISTIAN%20HIGH%20SCHOOL%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NASHWAUK-KEEWATIN%20SCHOOL%20DISTRICT</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/CaringBridge</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bi-county%20Community%20Action%20Programs%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Children's%20Dental%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Roers%20Companies%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/R.%20J.%20Ryan%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/JM%20Acquisition%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southland%20School%20District%20500</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/XeteX%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Crown%20Automotive%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Waltek%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Maple%20Island%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Meridian%20Blue%20Construction%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/UNITED%20HEALTHCARE</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ross%20Nesbit%20Agencies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Longevity%20Holdings%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Davis%20Mechanical%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Spring%20Prairie%20Hutterian%20Brethren%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HELLMUTH%20%26%20JOHNSON%2C%20PLLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Concast%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/VALLEY%20PAVING%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Superior%20Companies%20of%20Minnesota%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PREFERRED%20POWDER%20COATING%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Redwood%20Falls</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hannay's%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Erickson%20Truck%20Sales%20%26%20Salvage%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WPT%20Capital%20Advisors%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/TDX%20Companies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quality%20Flow%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Auto-mark%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Keystone%20Community%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bethany%20on%20the%20Lake%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HistoSonics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Automatic%20Systems%20Co.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gurstel%20Law%20Firm%2C%20P.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Synergies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Midwest%20Mechanical%20Solutions</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Greenwood%20Place%20Ltd</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plus%20Relocation%20Services%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Incentive%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Saint%20Joseph</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MOMENTS%20HOSPICE%20OF%20MIAMI%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MMIC%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MAYO%20CLINIC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hiawatha%20Valley%20Education%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gillette%20Children's%20Hospital%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bellboy%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Access%20Genetics%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dan%20%26%20Jerry's%20Greenhouses%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Minnesota%20Diversified%20Industries%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Xcel%20Energy%20Inc.%20Master%20Pension%20Trust</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/RED%20LAKE%20PUBLIC%20SCHOOLS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mains'l%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Youable%20Emotional%20Health%20Services</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/GLACIAL%20RIDGE%20HOSPITAL%20FOUNDATION%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Nextera%20Communications%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Hy-Tec%20Construction%20of%20Brainerd%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/NetSPI%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/G.O.%20Corporation%20I</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/WAV%20Aviation%20Corp.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MEAT%20AT%20VON%20HANSONS%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FRASER-MORRIS%20ELECTRIC%20CO.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Von%20Ruden%20Manufacturing%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Zeman%20Construction%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/21st%20Century%20Bank</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ARGONAUT%20MINNESOTA%20VENTURES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pump%20And%20Meter%20Service%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Indeed%20Brewing%20Company%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lewiston%20Altura%20Public%20Schools</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/FRAUEN%20SHUH%20COMPANIES</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Monarch%20Healthcare%20Management%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Superior%20Feed%20Ingredients%2C%20L.L.C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Beacon%20Academy</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Emergent%20Software%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Clearwater-Polk%20Electric%20Cooperative%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Integrated%20Building%20Solutions%20L.%20L.%20C.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/METRO%20DEAF%20SCHOOL</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Gaughan%20Enterprises%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stein's%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Graphic%20Systems%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wakefield%20Pork%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Premier%20OBGYN%20of%20Minnesota%2C%20PLLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Saluda%20Medical%20Americas%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Aggressive%20Hydraulics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Foodsby%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/US%20BANK%20STADIUM%20(SMG)</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Salon%20Innovations%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SJ%20ELECTRO%20SYSTEMS%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Butterfield%20Foods%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Kaleidoscope%20Charter%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/EAST%20VIEW%20INFORMATION%20SERVICES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Westwood%20Professional%20Services%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/City%20of%20Minnetrista</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Duininck%20Companies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quist%20Electronics%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Liberty%20Oxygen%20and%20Homecare%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Red%20Rock%20Central%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Allstates%20Pavement%20Recycling%20%26%20Stabilization%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/J%20%26%20J%20Meyer%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Casper%20Construction%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Multicare%20Associates%20Of%20The%20Twin%20Cities%2C%20P.A.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Portable%20Storage%20Of%20MN%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plaisted%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Van%20Paper%20Supply%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mountain%20Lake%20Public%20Schools%20Ind%20Sch%20Dist%20173</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/SheetMetal%20Workers%20Local%2010</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dean's%20Bulk%20Service%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Customer%20Elation%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Shingobee%20Builders%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mytech%20Partners%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Industrial%20Hardwood%20Products%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Retail%20Contracting%20Group%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/U.S.%20Sitework%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Chamberlain%20Oil%20Co.%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Granite%20Equity%20Partners%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ATEK%20Access%20Technologies%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Wellspring%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Condux%20International%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Anteris%20Technologies%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/MERCY%20HOSPITAL%20-%20UNITY%20CAMPUS</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Sleepy%20Eye%20School%20District%2084</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dynamic%20Homes%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Quality%20Forklift%20Sales%20and%20Service%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/STRIDE%20ACADEMY</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Barrett%20AG%20Service%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Proterra%20Investment%20Partners%20LP</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Browerville%20Independent%20School%20District</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/C.%20Emery%20Nelson%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Pact%20Charter%20School</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/B.%20H.%20HESELTON%20CO.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PILGRIM'S%20PRIDE%20CORPORATION</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/KGM%20Contractors%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Desiring%20God%20Ministries</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Veit%20Container%20Corporation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dahlheimer%20Beverage%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rotary%20Systems%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Diamond%20Surface%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/COUNTRY%20INN%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/YourSix%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Dhb%20Holdings%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Southeastern%20Minnesota%20Center%20For%20Independent%20Living%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Medina%20Electric%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Ultimate%20Safety%20Concepts%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ST.%20ANTHONY%20PARK%20HOME%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/American%20Financial%20Printing%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bell%20Pharmaceuticals%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Philkot%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Plaas%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Phaedon%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Preferred%20Electric%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Rainville-Carlson%2C%20Incorporated</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/The%20Saint%20Paul%20Chamber%20Orchestra%20Society</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Best%20Enterprises%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Berry%20Pallets%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Metropolitan%20Center%20for%20Independent%20Living</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Feltl%20and%20Company%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Meribel%20Enterprises%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Second%20Bite%20Foods%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Evergreen%20Innovations%2C%20Inc</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Lake%20Central%20Financial%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Initiative%20Foundation</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Mille%20Lacs%20Corporate%20Ventures</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Episcopal%20Homes%20on%20University%20Avenue%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ANIP%20Acquisition%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Massman%20Companies%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Marine%20Bancshares%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/ROWCAL%20NATION%2C%20LLC</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/West%20Wind%20Village</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/PARAGON%20STORE%20FIXTURES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/EXCELL%20ACADEMY%20FOR%20HIGHER%20LEARNING%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Stonebrooke%20Equipment%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/Bio%20Company</loc>
-    <lastmod>2025-09-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://minnesotadirectory.com/company/Hiller%20Stores%2C%20Inc.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://minnesotadirectory.com/company/HORIZON%20HOMES%2C%20INC.</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://minnesotadirectory.com/company/Hiller%20Stores%2C%20Inc.</loc>
+    <lastmod>2025-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { neon } from '@neondatabase/serverless';
+import { neon } from '@netlify/neon';
 import Papa from 'papaparse';
 
 const DOMAIN = 'https://minnesotadirectory.com'; // Update with actual domain when available


### PR DESCRIPTION
Update pnpm lockfile and replace `@neondatabase/serverless` with `@netlify/neon` to fix Netlify build failures.

The build initially failed due to an outdated `pnpm-lock.yaml` after `@neondatabase/serverless` was removed from `package.json`. After updating the lockfile, the build continued to fail because several scripts and Netlify functions were still importing the removed package, which was resolved by switching to `@netlify/neon`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3cf77de-1ea1-4b24-a153-e3db11dff576">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3cf77de-1ea1-4b24-a153-e3db11dff576">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

